### PR TITLE
Use allow-prereleases instead of the deprecated allows-prereleases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pugsql = "^0.1.7"
 [tool.poetry.dev-dependencies]
 flake8 = "^3.6"
 pytest = "^5.1"
-black = {version = "^19.3b0",allows-prereleases = true}
+black = {version = "^19.3b0",allow-prereleases = true}
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
### Description
Use `allow-prereleases` instead of the deprecated `allows-prereleases`.

This fixes the following warning:
```
The "black" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
```