### PR TITLE
Use Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: "python"
 sudo: required
 dist: xenial
 
-python:
-  - "3.6"
-  - "3.7"
+python: "3.8"
 
 branches:
   only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 
 WORKDIR /usr/src/app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/thaliawww/what-are-we-eating-today"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "~3.8"
 requests = "^2.21"
 pugsql = "^0.1.7"
 


### PR DESCRIPTION
### Description
Python 3.8 is being used in the Docker image (because it is based on `python:3`). This PR adds Python 3.8 to the CI and makes sure Python 3.8 is used everywhere.